### PR TITLE
Allow creating ingredients ad hoc

### DIFF
--- a/app/controllers/ingredients_controller.rb
+++ b/app/controllers/ingredients_controller.rb
@@ -28,7 +28,13 @@ class IngredientsController < ApplicationController
     @ingredient = current_user.ingredients.new(ingredient_params)
 
     if @ingredient.save
-      redirect_to ingredient_url(@ingredient)
+      if params[:ingredient][:recipe_id].present?
+        # Ad hoc adding of ingredient
+        redirect_to recipe_url(Recipe.find(params[:ingredient][:recipe_id]), edited_section: :ingredients, preselected_ingredient_id: @ingredient.id)
+      else
+        redirect_to ingredient_url(@ingredient)
+      end
+
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/javascript/controllers/turbo_modal_controller.js
+++ b/app/javascript/controllers/turbo_modal_controller.js
@@ -5,6 +5,12 @@ export default class extends Controller {
     this.element.parentElement.classList.remove("hidden")
   }
 
+  justHideModal() {
+    this.element.parentElement.removeAttribute("src") // it might be nice to also remove the modal SRC
+    this.element.parentElement.classList.add("hidden")
+    this.element.remove()
+  }
+
   hideModal() {
     this.element.parentElement.removeAttribute("src") // it might be nice to also remove the modal SRC
     this.element.parentElement.classList.add("hidden")

--- a/app/views/ingredients/_form.html.slim
+++ b/app/views/ingredients/_form.html.slim
@@ -1,11 +1,11 @@
 /# locals: (ingredient:, recipe_id: nil)
 
-= default_form_for ingredient do |form|
+= default_form_for ingredient, data: { action: "submit->turbo-modal#justHideModal" } do |form|
   = form.input :recipe_id, as: :hidden, input_html: { value: recipe_id }
   = form.input :name, col_span: :full, autofocus: true
   = form.input :description, col_span: :full
   = form.association :measurement, col_span: 6
   = form.association :category, col_span: 6
   = form.buttons_section
-    = form.cancel_link
+    = form.cancel_link if recipe_id.nil?
     = form.submit

--- a/app/views/ingredients/_form.html.slim
+++ b/app/views/ingredients/_form.html.slim
@@ -1,6 +1,7 @@
-/# locals: (ingredient:)
+/# locals: (ingredient:, recipe_id: nil)
 
 = default_form_for ingredient do |form|
+  = form.input :recipe_id, as: :hidden, input_html: { value: recipe_id }
   = form.input :name, col_span: :full, autofocus: true
   = form.input :description, col_span: :full
   = form.association :measurement, col_span: 6

--- a/app/views/ingredients/new.html.slim
+++ b/app/views/ingredients/new.html.slim
@@ -1,3 +1,12 @@
 - content_for :title, "přidat surovinu"
 
-== render "form", ingredient: @ingredient
+- if params[:recipe_id].present?
+  = turbo_frame_tag "modal" do
+    .modal-content data-controller="turbo-modal"
+      .flex.justify-end
+        button data-action="click->turbo-modal#hideModal keyup@window->turbo-modal#closeWithKeyboard click@window->turbo-modal#closeBackground"
+          = icon(:x, height: 24)
+
+      == render "form", ingredient: @ingredient, recipe_id: params[:recipe_id]
+- else
+  == render "form", ingredient: @ingredient, recipe_id: params[:recipe_id]

--- a/app/views/recipes/_ingredients_edit.html.slim
+++ b/app/views/recipes/_ingredients_edit.html.slim
@@ -1,4 +1,4 @@
-/# locals: (recipe:)
+/# locals: (recipe:, preselected_ingredient_id: nil)
 
 .col-span-12
   = heading("suroviny", :h2)
@@ -31,13 +31,15 @@
 
     #add-ingredient.mb-4
       = default_form_for "", url: recipe_ingredients_path(recipe_id: recipe.id), method: :post do |form|
-        - unused_ingredients = current_user.ingredients - recipe.ingredients
+        - unused_ingredients = current_user.ingredients.includes(:measurement) - recipe.ingredients.includes(:measurement)
         = form.input :ingredient_id, as: :combobox, collection: [ [ "moje",  unused_ingredients.collect { |v| [ v.name_with_unit, v.id ] } ],
                                              [ "veřejné", Ingredient.common.collect { |v| [ v.name_with_unit, v.id ] } ] ],
-                                             col_span: 4, group_method: :last, label: false, allow_blank: false
+                                             col_span: 4, group_method: :last, label: false, allow_blank: false, input_html: { value: preselected_ingredient_id.to_i }
         = form.input :amount, col_span: 3, label: false
         = form.input :comment, col_span: 3, required: false, label: false
         .col-span-2
           = form.submit "přidat", class: "mt-2"
+
+    = button_link_to "přidat ad-hoc surovinu", new_ingredient_path(recipe_id: recipe.id), data: { turbo_frame: "modal" }
 
   = button_link_to "hotovo!", recipe_path(recipe)

--- a/app/views/recipes/show.html.slim
+++ b/app/views/recipes/show.html.slim
@@ -30,7 +30,7 @@
 .md:grid.md:grid-cols-2
   .pr-2.md:col-span-1
     - if @edited_section == :ingredients
-      = render "ingredients_edit", recipe: @recipe
+      = render "ingredients_edit", recipe: @recipe, preselected_ingredient_id: params[:preselected_ingredient_id]
     - else
       = render "ingredients", recipe: @recipe
 


### PR DESCRIPTION
To by šlo. Není to kódově nejčistší, to zavírání modalu on-submit se mi úplně nelíbí (měl by se skrýt na redirect), ale funguje to. Vyplnění přes parametr je asi v pořádku

[Screencast from 2024-06-03 10-58-17.webm](https://github.com/janpeterka/kucharka-on-rails/assets/6343648/8fc0037e-f63a-4727-8cfc-e2b80896ffa6)

Zkoušel jsem to přes `data-turbo-frame="_top`, ale to nefunguje, protože modal je `turbo-permanent`.
Dá se vypnout turbo, ale pak se nedrží pozice.
