### PR TITLE
Move LegacyAuthentication concern

### DIFF
--- a/app/models/concerns/user/legacy_authentication.rb
+++ b/app/models/concerns/user/legacy_authentication.rb
@@ -1,0 +1,48 @@
+module User::LegacyAuthentication
+  extend ActiveSupport::Concern
+
+  def valid_password?(password)
+    if Devise::Encryptor.compare(self.class, encrypted_password, password)
+      true
+    elsif legacy_valid_password?(password)
+      self.password = password
+      self.legacy_password = nil
+      save!
+      true
+    else
+      false
+    end
+  end
+
+  def set_legacy_columns
+    self.active = true
+    self.fs_uniquifier = SecureRandom.hex(16)
+  end
+
+  # private
+
+  def legacy_valid_password?(password)
+    require "bcrypt"
+    bcrypt_password = BCrypt::Password.new(legacy_password)
+
+    hmaced_password = User.get_hmac(password)
+    hashed_password = BCrypt::Engine.hash_secret(hmaced_password, bcrypt_password.salt)
+
+    Devise.secure_compare(hashed_password, legacy_password)
+  rescue BCrypt::Errors::InvalidHash
+    false
+  end
+
+  def self.get_hmac(password)
+    require "openssl"
+    require "base64"
+
+    salt = Rails.application.credentials.LEGACY_SECURITY_SALT || ENV["LEGACY_SECURITY_SALT"]
+
+    raise "The configuration value `LEGACY_SECURITY_SALT` must not be None" if salt.nil?
+
+    digest = OpenSSL::Digest.new("sha512")
+    hmac = OpenSSL::HMAC.digest(digest, salt, password)
+    Base64.encode64(hmac).chomp.gsub(/\n/, "")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   include User::Omniauthable
+  include User::LegacyAuthentication # this makes migration from Flask-Security possible
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable
   devise :database_authenticatable, :registerable,
@@ -35,50 +36,5 @@ class User < ApplicationRecord
 
   def admin?
     id == 1
-  end
-
-  def valid_password?(password)
-    if Devise::Encryptor.compare(self.class, encrypted_password, password)
-      true
-    elsif legacy_valid_password?(password)
-      self.password = password
-      self.legacy_password = nil
-      save!
-      true
-    else
-      false
-    end
-  end
-
-  # private
-
-  def legacy_valid_password?(password)
-    require "bcrypt"
-    bcrypt_password = BCrypt::Password.new(legacy_password)
-
-    hmaced_password = User.get_hmac(password)
-    hashed_password = BCrypt::Engine.hash_secret(hmaced_password, bcrypt_password.salt)
-
-    Devise.secure_compare(hashed_password, legacy_password)
-  rescue BCrypt::Errors::InvalidHash
-    false
-  end
-
-  def self.get_hmac(password)
-    require "openssl"
-    require "base64"
-
-    salt = Rails.application.credentials.LEGACY_SECURITY_SALT || ENV["LEGACY_SECURITY_SALT"]
-
-    raise "The configuration value `LEGACY_SECURITY_SALT` must not be None" if salt.nil?
-
-    digest = OpenSSL::Digest.new("sha512")
-    hmac = OpenSSL::HMAC.digest(digest, salt, password)
-    Base64.encode64(hmac).chomp.gsub(/\n/, "")
-  end
-
-  def set_legacy_columns
-    self.active = true
-    self.fs_uniquifier = SecureRandom.hex(16)
   end
 end


### PR DESCRIPTION
Move logic around legacy authentication to separate concern for easier management (and later deletion)